### PR TITLE
Introduce resource limits to kube-plex annotations

### DIFF
--- a/charts/kube-plex/templates/deployment.yaml
+++ b/charts/kube-plex/templates/deployment.yaml
@@ -34,6 +34,12 @@ spec:
         {{- if .Values.kubePlex.loglevel }}
         kube-plex/loglevel: "{{ .Values.kubePlex.loglevel }}"
         {{- end }}
+        {{- if .Values.kubePlex.resources.requests }}
+        kube-plex/resources-requests: {{ toJson .Values.kubePlex.resources.requests }}
+        {{- end}}
+        {{- if .Values.kubePlex.resources.limits }}
+        kube-plex/resources-limits: {{ toJson .Values.kubePlex.resources.limits }}
+        {{- end}}
       {{- if .Values.podAnnotations }}
         {{- range $key, $value := .Values.podAnnotations }}
         {{ $key }}: {{ $value | quote }}

--- a/charts/kube-plex/templates/deployment.yaml
+++ b/charts/kube-plex/templates/deployment.yaml
@@ -40,6 +40,9 @@ spec:
         {{- if .Values.kubePlex.resources.limits }}
         kube-plex/resources-limits: {{ toJson .Values.kubePlex.resources.limits | quote }}
         {{- end}}
+        {{- if .Values.kubePlex.mounts }}
+        kube-plex/mounts: {{ .Values.kubePlex.mounts }}
+        {{- end}}
       {{- if .Values.podAnnotations }}
         {{- range $key, $value := .Values.podAnnotations }}
         {{ $key }}: {{ $value | quote }}

--- a/charts/kube-plex/templates/deployment.yaml
+++ b/charts/kube-plex/templates/deployment.yaml
@@ -35,10 +35,10 @@ spec:
         kube-plex/loglevel: "{{ .Values.kubePlex.loglevel }}"
         {{- end }}
         {{- if .Values.kubePlex.resources.requests }}
-        kube-plex/resources-requests: {{ toJson .Values.kubePlex.resources.requests }}
+        kube-plex/resources-requests: {{ toJson .Values.kubePlex.resources.requests | quote }}
         {{- end}}
         {{- if .Values.kubePlex.resources.limits }}
-        kube-plex/resources-limits: {{ toJson .Values.kubePlex.resources.limits }}
+        kube-plex/resources-limits: {{ toJson .Values.kubePlex.resources.limits | quote }}
         {{- end}}
       {{- if .Values.podAnnotations }}
         {{- range $key, $value := .Values.podAnnotations }}

--- a/charts/kube-plex/values.yaml
+++ b/charts/kube-plex/values.yaml
@@ -23,6 +23,11 @@ kubePlex:
     # limits:
     #   "gpu.intel.com/i915: 1
 
+  # Mounts which should be carried over to kube-plex transcoder. By default only
+  # /data and /transcode are cloned to the transcoding pod. A comma separated list.
+  #
+  ## mounts: /data,/transcode
+
 
 # Override this with the plex claim token from plex.tv/claim
 claimToken: ""

--- a/charts/kube-plex/values.yaml
+++ b/charts/kube-plex/values.yaml
@@ -13,6 +13,16 @@ kubePlex:
     repository: quay.io/munnerz/kube-plex
     tag: latest
     pullPolicy: Always
+  resources: {}
+    # Limits and requests that are applied to the kube-plex transcoding pod. Can
+    # be used to request GPU instances for pods as well as normal Kubernetes
+    # limits.
+    # requests:
+    #   cpu: 100m
+    #   "gpu.intel.com/i915: 1
+    # limits:
+    #   "gpu.intel.com/i915: 1
+
 
 # Override this with the plex claim token from plex.tv/claim
 claimToken: ""

--- a/cmd/kube-plex/kubernetes.go
+++ b/cmd/kube-plex/kubernetes.go
@@ -52,6 +52,7 @@ func generateJob(cwd string, m PmsMetadata, env []string, args []string) (*batch
 								[]corev1.VolumeMount{{Name: "shared", MountPath: "/shared"}},
 								m.VolumeMounts...,
 							),
+							Resources: m.ResourceRequirements(),
 						},
 					},
 					InitContainers: []corev1.Container{{

--- a/cmd/kube-plex/kubernetes_test.go
+++ b/cmd/kube-plex/kubernetes_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-test/deep"
 	batch "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -190,6 +191,7 @@ func Test_podWatcher(t *testing.T) {
 }
 
 func Test_generateJob(t *testing.T) {
+	cpuMilli, _ := resource.ParseQuantity("100m")
 	md := PmsMetadata{
 		Name:          "pms",
 		Namespace:     "plex",
@@ -201,7 +203,8 @@ func Test_generateJob(t *testing.T) {
 			{Name: "data", VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "datapvc"}}},
 			{Name: "transcode", VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "transcodepvc"}}},
 		},
-		VolumeMounts: []corev1.VolumeMount{{Name: "data", MountPath: "/data"}, {Name: "transcode", MountPath: "/transcode"}},
+		VolumeMounts:     []corev1.VolumeMount{{Name: "data", MountPath: "/data"}, {Name: "transcode", MountPath: "/transcode"}},
+		ResourceRequests: corev1.ResourceList{corev1.ResourceCPU: cpuMilli},
 	}
 	e := []string{"FOO=bar", "BAR=oof"}
 	a := []string{"a", "b", "c"}
@@ -245,6 +248,9 @@ func Test_generateJob(t *testing.T) {
 							{Name: "shared", MountPath: "/shared", ReadOnly: false},
 							{Name: "data", MountPath: "/data", ReadOnly: false},
 							{Name: "transcode", MountPath: "/transcode", ReadOnly: false},
+						},
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{corev1.ResourceCPU: cpuMilli},
 						},
 					}},
 					Volumes: []corev1.Volume{


### PR DESCRIPTION
Allow defining requests and limits for the kube-plex pod using
annotations. This enables usage of things like GPUs for transcoding.

Define kubeplex resource limits in values to use. For example:

```yaml
image:
  tag: latest
kubePlex:
  enabled: true
  image:
    repository: ghcr.io/ressu/kube-plex
  loglevel: verbose
  resources:
    limits:
      cpu: 1
```