### PR TITLE
Introduce custom probes

### DIFF
--- a/charts/kube-plex/README.md
+++ b/charts/kube-plex/README.md
@@ -7,7 +7,7 @@ The following tables lists the configurable parameters of the Plex chart and the
 | Parameter                  | Description                         | Default                                                 |
 |----------------------------|-------------------------------------|---------------------------------------------------------|
 | `image.repository`         | Image repository | `plexinc/pms-docker` |
-| `image.tag`                | Image tag. Possible values listed [here](https://hub.docker.com/r/plexinc/pms-docker/tags/).| `1.10.1.4602-f54242b6b`|
+| `image.tag`                | Image tag. Possible values listed [here](https://hub.docker.com/r/plexinc/pms-docker/tags/).| `1.16.0.1226-7eb2c8f6f`|
 | `image.pullPolicy`         | Image pull policy | `IfNotPresent` |
 | `kubePlex.enabled`         | Enable KubPlex transcoder | `true` |
 | `kubePlex.image.repository`         | Image repository | `quay.io/munnerz/kube-plex` |
@@ -20,10 +20,19 @@ The following tables lists the configurable parameters of the Plex chart and the
 | `service.annotations`   | Service annotations for the Plex GUI | `{}` |
 | `service.labels`        | Custom labels | `{}` |
 | `service.loadBalancerIP` | Load balancer IP for the Plex GUI; set `service.type` to `LoadBalancer` to use this. | `{}` |
-| `service.loadBalancerSourceRanges` | List of IP CIDRs allowed access to load balancer (if supported)      | None
+| `service.loadBalancerSourceRanges` | List of IP CIDRs allowed access to load balancer (if supported)      | None |
+| `probes.liveness.custom` | Set this to `true` if you wish to specify your own livenessProbe | `false` |
+| `probes.liveness.enabled` | Enable the liveness probe | `true` |
+| `probes.liveness.spec` | The spec field contains the values for the default livenessProbe. If you selected `custom: true`, this field holds the definition of the livenessProbe. | `` |
+| `probes.readiness.custom` | Set this to `true` if you wish to specify your own readinessProbe | `false` |
+| `probes.readiness.enabled` | Enable the readiness probe | `true` |
+| `probes.readiness.spec` | The spec field contains the values for the default readinessProbe. If you selected `custom: true`, this field holds the definition of the readinessProbe. | `` |
+| `probes.startup.custom` | Set this to `true` if you wish to specify your own startupProbe | `false` |
+| `probes.startup.enabled` | Enable the startup probe | `true` |
+| `probes.startup.spec` | The spec field contains the values for the default startupProbe. If you selected `custom: true`, this field holds the definition of the startupProbe. |
 | `ingress.enabled`              | Enables Ingress | `false` |
 | `ingress.annotations`          | Ingress annotations | `{}` |
-| `ingress.labels`               | Custom labels                       | `{}`
+| `ingress.labels`               | Custom labels | `{}` |
 | `ingress.path`                 | Ingress path | `/` |
 | `ingress.hosts`                | Ingress accepted hostnames | `chart-example.local` |
 | `ingress.tls`                  | Ingress TLS configuration | `[]` |

--- a/charts/kube-plex/templates/deployment.yaml
+++ b/charts/kube-plex/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
         release: {{ .Release.Name }}
       annotations:
         kube-plex/container-name: "kube-plex-init"
-        kube-plex/pms-addr: {{ template "fullname" . }}:32400
+        kube-plex/pms-addr: {{ template "fullname" . }}:{{ .Values.service.port }}
         kube-plex/pms-container-name: "plex"
         {{- if .Values.kubePlex.loglevel }}
         kube-plex/loglevel: "{{ .Values.kubePlex.loglevel }}"
@@ -83,23 +83,27 @@ spec:
                 mv '/usr/lib/plexmediaserver/Plex Transcoder' '/usr/lib/plexmediaserver/Plex Transcoder.orig' 
                 cp /shared/kube-plex '/usr/lib/plexmediaserver/Plex Transcoder'
 {{- end }}
-        readinessProbe:
-          httpGet:
-            path: /identity
-            port: 32400
-          initialDelaySeconds: 15
-          timeoutSeconds: 5
-        livenessProbe:
-          httpGet:
-            path: /identity
-            port: 32400
-          initialDelaySeconds: 10
-          timeoutSeconds: 10
+{{- range $probeName, $probe := .Values.probes }}
+  {{- if $probe.enabled -}}
+    {{- "" | nindent 8 }}
+    {{- $probeName }}Probe:
+    {{- if $probe.custom -}}
+      {{- $probe.spec | toYaml | nindent 10 }}
+    {{- else }}
+      {{- "tcpSocket:" | nindent 10 }}
+        {{- printf "port: %v" $.Values.service.port  | nindent 12 }}
+      {{- printf "initialDelaySeconds: %v" $probe.spec.initialDelaySeconds  | nindent 10 }}
+      {{- printf "failureThreshold: %v" $probe.spec.failureThreshold  | nindent 10 }}
+      {{- printf "timeoutSeconds: %v" $probe.spec.timeoutSeconds  | nindent 10 }}
+      {{- printf "periodSeconds: %v" $probe.spec.periodSeconds | nindent 10 }}
+    {{- end }}
+  {{- end }}
+{{- end }}
         ports:
           - name: pms
-            containerPort: 32400
+            containerPort: {{ .Values.service.port }}
           - name: http
-            containerPort: 32400
+            containerPort: {{ .Values.service.port }}
           - name: https
             containerPort: 32443
         env:

--- a/charts/kube-plex/templates/volumes.yaml
+++ b/charts/kube-plex/templates/volumes.yaml
@@ -11,7 +11,7 @@ metadata:
     component: transcode
 spec:
   accessModes:
-  - {{ .Values.persistence.config.accessMode | quote }}
+  - {{ .Values.persistence.transcode.accessMode | quote }}
   resources:
     requests:
       storage: {{ .Values.persistence.transcode.size | quote }}

--- a/charts/kube-plex/values.yaml
+++ b/charts/kube-plex/values.yaml
@@ -56,6 +56,51 @@ service:
   ## Set the externalTrafficPolicy in the Service to either Cluster or Local
   # externalTrafficPolicy: Cluster
 
+# Probe configuration
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes
+probes:
+  # Liveness probe configuration
+  liveness:
+    # Enable the liveness probe
+    enabled: true
+    # Set custom to `true` if you wish to specify your own liveness probe
+    custom: false
+    # The spec field contains the values for the default livenessProbe.
+    # If you selected `custom: true`, the spec field holds the definition of the livenessProbe.
+    spec:
+      initialDelaySeconds: 0
+      periodSeconds: 10
+      timeoutSeconds: 1
+      failureThreshold: 3
+
+  # Redainess probe configuration
+  readiness:
+    # Enable the readiness probe
+    enabled: true
+    # Set custom to `true` if you wish to specify your own readiness probe
+    custom: false
+    # The spec field contains the values for the default readinessProbe.
+    # If you selected `custom: true`, this field holds the definition of the readinessProbe.
+    spec:
+      initialDelaySeconds: 0
+      periodSeconds: 10
+      timeoutSeconds: 1
+      failureThreshold: 3
+
+  # Startup probe configuration
+  startup:
+    # Enable the startup probe
+    enabled: true
+    # Set custom to `true` if you wish to specify your own startup probe
+    custom: false
+    # The spec field contains the values for the default startupProbe.
+    # If you selected `custom: true`, this field holds the definition of the startupProbe.
+    spec:
+      initialDelaySeconds: 0
+      timeoutSeconds: 1
+      periodSeconds: 5
+      failureThreshold: 30
+
 ingress:
   enabled: false
   # Used to create an Ingress record.


### PR DESCRIPTION
This PR addresses #3 and includes the following:
- Adds startup probe and defaults (requires K8s 1.16+, can be disabled)
- Introduces the ability to specify custom definitions for readiness, liveness, and startup probes.
- Changes the default probe type to `tcpSocket`, from the old hardcoded `httpGet` to /identity
- Utilizes service.port anywhere 32400 was hardcoded in the deployment
- Updates to the README