### PR TITLE
Introduce EAE transcoding support for elastic transcoding jobs

### DIFF
--- a/charts/kube-plex/templates/deployment.yaml
+++ b/charts/kube-plex/templates/deployment.yaml
@@ -34,6 +34,9 @@ spec:
         {{- if .Values.kubePlex.loglevel }}
         kube-plex/loglevel: "{{ .Values.kubePlex.loglevel }}"
         {{- end }}
+        {{- if .Values.kubePlex.eaeRootDir }}
+        kube-plex/eae-root-dir: "{{ .Values.kubePlex.eaeRootDir }}"
+        {{- end }}
         {{- if .Values.kubePlex.resources.requests }}
         kube-plex/resources-requests: {{ toJson .Values.kubePlex.resources.requests | quote }}
         {{- end}}

--- a/cmd/kube-plex/kubernetes.go
+++ b/cmd/kube-plex/kubernetes.go
@@ -92,6 +92,9 @@ func filterPodEnv(in []corev1.EnvVar) []corev1.EnvVar {
 		case "FFMPEG_EXTERNAL_LIBS":
 			v.Value = ffmpeg.Unescape(v.Value)
 			out = append(out, v)
+		case "EAE_ROOT":
+			v.Value = ffmpeg.Unescape(v.Value)
+			out = append(out, v)
 		default:
 			out = append(out, v)
 		}

--- a/cmd/kube-plex/kubernetes_test.go
+++ b/cmd/kube-plex/kubernetes_test.go
@@ -45,6 +45,7 @@ func Test_filterPodEnv(t *testing.T) {
 		{"nothing to filter", []corev1.EnvVar{{Name: "SHELL", Value: "/bin/false"}}, []corev1.EnvVar{{Name: "SHELL", Value: "/bin/false"}}},
 		{"empty vars", []corev1.EnvVar{}, []corev1.EnvVar{}},
 		{"filter FFmpeg escaping", []corev1.EnvVar{{Name: "FFMPEG_EXTERNAL_LIBS", Value: "/path\\ to/codec"}}, []corev1.EnvVar{{Name: "FFMPEG_EXTERNAL_LIBS", Value: "/path to/codec"}}},
+		{"filter EAE root dir escaping", []corev1.EnvVar{{Name: "EAE_ROOT", Value: "/path\\ to/eae-root"}}, []corev1.EnvVar{{Name: "FFMPEG_EXTERNAL_LIBS", Value: "/path to/eae-root"}}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/kube-plex/kubernetes_test.go
+++ b/cmd/kube-plex/kubernetes_test.go
@@ -45,7 +45,7 @@ func Test_filterPodEnv(t *testing.T) {
 		{"nothing to filter", []corev1.EnvVar{{Name: "SHELL", Value: "/bin/false"}}, []corev1.EnvVar{{Name: "SHELL", Value: "/bin/false"}}},
 		{"empty vars", []corev1.EnvVar{}, []corev1.EnvVar{}},
 		{"filter FFmpeg escaping", []corev1.EnvVar{{Name: "FFMPEG_EXTERNAL_LIBS", Value: "/path\\ to/codec"}}, []corev1.EnvVar{{Name: "FFMPEG_EXTERNAL_LIBS", Value: "/path to/codec"}}},
-		{"filter EAE root dir escaping", []corev1.EnvVar{{Name: "EAE_ROOT", Value: "/path\\ to/eae-root"}}, []corev1.EnvVar{{Name: "FFMPEG_EXTERNAL_LIBS", Value: "/path to/eae-root"}}},
+		{"filter EAE root dir escaping", []corev1.EnvVar{{Name: "EAE_ROOT", Value: "/path\\ to/eae-root"}}, []corev1.EnvVar{{Name: "EAE_ROOT", Value: "/path to/eae-root"}}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/kube-plex/metadata.go
+++ b/cmd/kube-plex/metadata.go
@@ -37,6 +37,7 @@ type PmsMetadata struct {
 	KubePlexImage    string               // container image for kube-plex
 	KubePlexLevel    string               // loglevel of kubeplex processes
 	CodecPort        int                  // port on which the codec service runs
+	EaeRootDir       string               // directory to use for EAE encoding/decoding
 	PmsImage         string               // container image used by Plex Media Server
 	PmsAddr          string               // URL for Plex Media Server
 }
@@ -236,6 +237,9 @@ func (p PmsMetadata) LauncherCmd(args ...string) []string {
 	}
 	if p.KubePlexLevel != "" {
 		a = append(a, fmt.Sprintf("--loglevel=%s", p.KubePlexLevel))
+	}
+	if p.EaeRootDir != "" {
+		a = append(a, fmt.Sprintf("--eae-root-dir=%s", p.EaeRootDir))
 	}
 	a = append(a, "--")
 	return append(a, args...)

--- a/cmd/kube-plex/metadata.go
+++ b/cmd/kube-plex/metadata.go
@@ -21,6 +21,7 @@ const (
 	kubePlexContainer     = "kube-plex/container-name"
 	kubePlexResourceReq   = "kube-plex/resources-requests"
 	kubePlexResourceLimit = "kube-plex/resources-limits"
+	eaeRootDir            = "kube-plex/eae-root-dir"
 )
 
 // PmsMetadata describes a Plex Media Server instance running in kubernetes.
@@ -90,6 +91,10 @@ func FetchMetadata(ctx context.Context, cl kubernetes.Interface, name, namespace
 		return PmsMetadata{}, fmt.Errorf("unable to determine kube-plex image (set init-container name with '%s' annotation): %v", kubePlexContainer, err)
 	}
 	m.KubePlexImage = kpimage
+
+	// EAE root dir override path
+	e := a[eaeRootDir]
+	m.EaeRootDir = e
 
 	// mounts to copy over
 	mlist, ok := a[pmsMounts]

--- a/cmd/kube-plex/metadata_test.go
+++ b/cmd/kube-plex/metadata_test.go
@@ -139,6 +139,7 @@ func Test_pmsMetadata_LauncherCmd(t *testing.T) {
 		{"generates bare cmd", PmsMetadata{PmsAddr: "a:32400"}, []string{"a"}, []string{"/shared/transcode-launcher", "--pms-addr=a:32400", "--listen=:32400", "--", "a"}},
 		{"generates codec server url", PmsMetadata{PmsAddr: "a:32400", PodIP: "1.2.3.4", CodecPort: 1234}, []string{"a"}, []string{"/shared/transcode-launcher", "--pms-addr=a:32400", "--listen=:32400", "--codec-server-url=http://1.2.3.4:1234/", "--codec-dir=/shared/codecs/", "--", "a"}},
 		{"generates debug flag", PmsMetadata{PmsAddr: "a:32400", KubePlexLevel: "debug"}, []string{"a"}, []string{"/shared/transcode-launcher", "--pms-addr=a:32400", "--listen=:32400", "--loglevel=debug", "--", "a"}},
+		{"generates eae root dir flag", PmsMetadata{PmsAddr: "a:32400", EaeRootDir: "/tmp/eae"}, []string{"a"}, []string{"/shared/transcode-launcher", "--pms-addr=a:32400", "--listen=:32400", "--eae-root-dir=/tmp/eae", "--", "a"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/transcode-launcher/main.go
+++ b/cmd/transcode-launcher/main.go
@@ -56,9 +56,19 @@ func launch() int {
 	}
 
 	if *eaeRootDir != "" {
-        eEaeRootDir := ffmpeg.Escape(*eaeRootDir)
+		eEaeRootDir := ffmpeg.Escape(*eaeRootDir)
 		klog.Infof("Updating environment, setting EAE_ROOT to '%v'", eEaeRootDir)
 		os.Setenv("EAE_ROOT", eEaeRootDir)
+
+		// Create needed directories for FFMPEG in $EAE_ROOT
+		eaeDirs := [6]string{"Convert to Dolby Digital (High Quality - 640 kbps)", "Convert to Dolby Digital (Low Quality - 384 kbps)", "Convert to Dolby Digital Plus (High Quality - 384 kbps)", "Convert to Dolby Digital Plus (Max Quality - 1024 kbps)", "Convert to WAV (to 2ch or less)", "Convert to WAV (to 8ch or less)"}
+		for _, value := range eaeDirs {
+			eaeDir := eEaeRootDir + "/" + value
+			klog.Infof("Creating EAE required directory: %s", eaeDir)
+			if _, err := os.Stat(eaeDir); os.IsNotExist(err) {
+				os.MkdirAll(eaeDir, 0755)
+			}
+		}
 	}
 
 	if *pmsAddr == "" {

--- a/cmd/transcode-launcher/main.go
+++ b/cmd/transcode-launcher/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 
 	"github.com/munnerz/kube-plex/internal/ffmpeg"
 	"github.com/munnerz/kube-plex/internal/logger"
@@ -63,7 +64,7 @@ func launch() int {
 		// Create needed directories for FFMPEG in $EAE_ROOT
 		eaeDirs := [6]string{"Convert to Dolby Digital (High Quality - 640 kbps)", "Convert to Dolby Digital (Low Quality - 384 kbps)", "Convert to Dolby Digital Plus (High Quality - 384 kbps)", "Convert to Dolby Digital Plus (Max Quality - 1024 kbps)", "Convert to WAV (to 2ch or less)", "Convert to WAV (to 8ch or less)"}
 		for _, value := range eaeDirs {
-			eaeDir := eEaeRootDir + "/" + value
+			eaeDir := filepath.Join(eaeRootDir, value)
 			klog.Infof("Creating EAE required directory: %s", eaeDir)
 			if _, err := os.Stat(eaeDir); os.IsNotExist(err) {
 				os.MkdirAll(eaeDir, 0755)

--- a/cmd/transcode-launcher/main.go
+++ b/cmd/transcode-launcher/main.go
@@ -64,7 +64,7 @@ func launch() int {
 		// Create needed directories for FFMPEG in $EAE_ROOT
 		eaeDirs := [6]string{"Convert to Dolby Digital (High Quality - 640 kbps)", "Convert to Dolby Digital (Low Quality - 384 kbps)", "Convert to Dolby Digital Plus (High Quality - 384 kbps)", "Convert to Dolby Digital Plus (Max Quality - 1024 kbps)", "Convert to WAV (to 2ch or less)", "Convert to WAV (to 8ch or less)"}
 		for _, value := range eaeDirs {
-			eaeDir := filepath.Join(eaeRootDir, value)
+			eaeDir := filepath.Join(*eaeRootDir, value)
 			klog.Infof("Creating EAE required directory: %s", eaeDir)
 			if _, err := os.Stat(eaeDir); os.IsNotExist(err) {
 				os.MkdirAll(eaeDir, 0755)

--- a/cmd/transcode-launcher/main.go
+++ b/cmd/transcode-launcher/main.go
@@ -17,6 +17,7 @@ var (
 	pmsAddr     = flag.String("pms-addr", "", "Address for the Plex Media Server instance (for example: '10.1.2.3:32400')")
 	codecServer = flag.String("codec-server-url", os.Getenv("CODEC_SERVER"), "URL for codec server (kube-plex)")
 	codecDir    = flag.String("codec-dir", os.Getenv("FFMPEG_EXTERNAL_LIBS"), "Directory to write codecs to, path will be created if doesn't exist")
+	eaeRootDir  = flag.String("eae-root-dir", os.Getenv("EAE_ROOT"), "Directory to use for EAE")
 	logLevel    = flag.String("loglevel", "", "Set the loglevel for transcoding process")
 )
 
@@ -52,6 +53,12 @@ func launch() int {
 		eCodecDir := ffmpeg.Escape(*codecDir)
 		klog.Infof("Updating environment, setting FFMPEG_EXTERNAL_LIBS to '%v'", eCodecDir)
 		os.Setenv("FFMPEG_EXTERNAL_LIBS", eCodecDir)
+	}
+
+	if *eaeRootDir != "" {
+        eEaeRootDir := ffmpeg.Escape(*eaeRootDir)
+		klog.Infof("Updating environment, setting EAE_ROOT to '%v'", eEaeRootDir)
+		os.Setenv("EAE_ROOT", eEaeRootDir)
 	}
 
 	if *pmsAddr == "" {


### PR DESCRIPTION
I'm not the most proficient in Go, but here is a patch that begins to add support for setting the `EAE_ROOT` environment variable which Plex's FFMPEG utilizes when transcoding EAE, to override the default `/tmp` path. I patterned it off of the functionality you added for `FFMPEG_EXTERNAL_LIBS` and the codec serving paths. 

I also don't have a great test setup for developing this locally yet, but I'll get that up at some point. I'm also not sure if this is something you've already looked into and tried @ressu but thought it was worth a shot and some discussion. It looks promising 😃 

Also, once this is tested, working well, and ready to be merged in, we could probably update the code so it doesn't bypass kube-plex for EAE. Turns out a large portion of my media hits this, and defeats the purpose of running kube-plex.