### PR TITLE
Add Kustomize based template example

### DIFF
--- a/examples/kustomize/README.md
+++ b/examples/kustomize/README.md
@@ -1,0 +1,61 @@
+# Example configuration for Kustomize based kube-plex setup
+
+This directory contains an example Kustomize based configuraiton for kube-plex.
+The configuration doesn't create PersistentVolume (PV) or PersistentVolumeClaim
+(PVC) objects. Creating PV and PVC definitions is left as a task to the cluster
+maintainer.
+
+## Using the templates with a two directory layout
+
+Templates can be used directly from this repository or the templates can be
+copied to a centralized storage. [Base](base/) directory contains a basic
+kube-plex installation. [Myplex](myplex/) directory is an overlay directory and
+contains an example on how to customise the base deployment.  All modifications
+to the deployment are made to the overlay directory.
+
+Two directory based setup is updated by replacing the base directory with the
+new version from upstream.
+
+## Configuration
+
+Overlay directory contains two evxample patches to the base deployment:
+- [deployment.yaml](myplex/deployment.yaml)
+- [service.yaml](myplex/service.yaml)
+
+Patch files update the full deployment in base directory. More details on how
+to use patches can be found in [kubectl
+documentation](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/patches/).
+
+In addition to patches, kustomize templates contain shared definitions:
+
+```yaml
+commonLabels:
+  release: my-plex
+namePrefix: my-
+namespace: plex
+```
+
+Namespace defines which namespace is used for deployment and overrides the
+definitions in yaml files. Common labels is an easy way of defining a label
+that is applied to all defined resources. Nameprefix and namesuffix can be used
+to change the names of deployed resources.
+
+## Applying and inspecting final configuration
+
+`Kubectl` can be used to apply the final configuration.
+
+```bash
+kubectl apply -k myplex/
+```
+
+To inspect what would be changed in a deployment, the `diff` command can be used:
+
+```bash
+kubectl diff -k myplex/
+```
+
+To inspect the complete template, a separate tool called `kustomize` can be used instead:
+
+```bash
+kustomize build myplex/
+```

--- a/examples/kustomize/base/config/namerefs.yaml
+++ b/examples/kustomize/base/config/namerefs.yaml
@@ -1,0 +1,5 @@
+nameReference:
+  - kind: Deployment
+    fieldSpecs:
+      - path: spec/template/spec/hostname
+        kind: Deployment

--- a/examples/kustomize/base/deployment.yaml
+++ b/examples/kustomize/base/deployment.yaml
@@ -1,0 +1,102 @@
+# Source: kube-plex/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-plex
+  labels:
+    app: kube-plex
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kube-plex
+  template:
+    metadata:
+      labels:
+        app: kube-plex
+      annotations:
+        kube-plex/container-name: "kube-plex-init"
+        # TODO: Update to labels
+        kube-plex/pms-addr: kube-plex:32400
+        kube-plex/pms-container-name: "plex"
+    spec:
+      serviceAccountName: kube-plex
+      # TODO: Make dynamic
+      hostname: "kube-plex"
+      nodeSelector:
+        beta.kubernetes.io/arch: amd64
+      initContainers:
+        - name: kube-plex-init
+          image: "ghcr.io/ressu/kube-plex:latest"
+          command:
+            - cp
+            - /kube-plex
+            - /shared/kube-plex
+          volumeMounts:
+            - name: shared
+              mountPath: /shared
+          imagePullPolicy: Always
+      containers:
+        - name: plex
+          image: "plexinc/pms-docker:1.23.5.4862-0f739d462"
+          ports:
+            - name: pms
+              containerPort: 32400
+            - name: http
+              containerPort: 32400
+            - name: https
+              containerPort: 32443
+          env:
+            # TODO: move this to a secret?
+            - name: PLEX_CLAIM
+              value: ""
+            # kube-plex env vars
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          resources: {}
+          volumeMounts:
+            - name: shared
+              mountPath: /shared
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            tcpSocket:
+              port: 32400
+            timeoutSeconds: 1
+          readinessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            tcpSocket:
+              port: 32400
+            timeoutSeconds: 1
+          # We replace the PMS binary with a postStart hook to save having to
+          # modify the default image entrypoint.
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - bash
+                  - -c
+                  - "#!/bin/bash\nset -e\nmv '/usr/lib/plexmediaserver/Plex Transcoder' '/usr/lib/plexmediaserver/Plex Transcoder.orig' \ncp /shared/kube-plex '/usr/lib/plexmediaserver/Plex Transcoder'\n"
+          imagePullPolicy: IfNotPresent
+          startupProbe:
+            failureThreshold: 30
+            initialDelaySeconds: 0
+            periodSeconds: 5
+            tcpSocket:
+              port: 32400
+            timeoutSeconds: 1
+      volumes:
+        - name: shared
+          emptyDir: {}
+  strategy:
+    type: Recreate
+  revisionHistoryLimit: 3

--- a/examples/kustomize/base/kustomization.yaml
+++ b/examples/kustomize/base/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - role.yaml
+  - rolebinding.yaml
+  - service.yaml
+  - serviceaccount.yaml
+commonLabels:
+  app: kube-plex
+configurations:
+  - config/namerefs.yaml

--- a/examples/kustomize/base/role.yaml
+++ b/examples/kustomize/base/role.yaml
@@ -1,0 +1,37 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kube-plex
+  labels:
+    app: kube-plex
+rules:
+  - resources:
+      - pods
+      - pods/attach
+      - pods/exec
+      - pods/portforward
+      - pods/proxy
+    apiGroups:
+      - ""
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - resources:
+      - jobs
+    apiGroups:
+      - batch
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch

--- a/examples/kustomize/base/rolebinding.yaml
+++ b/examples/kustomize/base/rolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kube-plex
+  labels:
+    app: kube-plex
+roleRef:
+  name: kube-plex
+  kind: Role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - name: kube-plex
+    namespace: "plex"
+    kind: ServiceAccount

--- a/examples/kustomize/base/service.yaml
+++ b/examples/kustomize/base/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-plex
+  labels:
+    app: kube-plex
+spec:
+  type: LoadBalancer
+  selector:
+    app: kube-plex
+  ports:
+    - name: pms
+      protocol: TCP
+      port: 32400
+      targetPort: pms
+    - name: http
+      port: 80
+      targetPort: pms
+    - name: https
+      port: 443
+      targetPort: 32443

--- a/examples/kustomize/base/serviceaccount.yaml
+++ b/examples/kustomize/base/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-plex

--- a/examples/kustomize/base/sevicename.yaml
+++ b/examples/kustomize/base/sevicename.yaml
@@ -1,0 +1,12 @@
+source:
+  kind: Service
+  name: kube-plex
+targets:
+  - select:
+      kind: Deployment
+      name: kube-plex
+    fieldPaths:
+      - spec.template.metadata.annotations.kube-plex/pms-addr
+    options:
+      delimiter: ":"
+      index: 1

--- a/examples/kustomize/myplex/deployment.yaml
+++ b/examples/kustomize/myplex/deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-plex
+spec:
+  template:
+    metadata:
+      annotations:
+        kube-plex/pms-addr: my-kube-plex:32400
+    spec:
+      containers:
+        - name: plex
+          env:
+            - name: TZ
+              value: "Europe/Dublin"
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: config
+              mountPath: /config
+            - name: transcode
+              mountPath: /transcode
+              subPath: aniplex
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: "plex-media"
+        - name: config
+          persistentVolumeClaim:
+            claimName: "my-plex-config"
+        - name: transcode
+          persistentVolumeClaim:
+            claimName: "plex-transcode"

--- a/examples/kustomize/myplex/kustomization.yaml
+++ b/examples/kustomize/myplex/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+commonLabels:
+  release: my-plex
+namePrefix: my-
+namespace: plex
+patches:
+  - path: deployment.yaml
+    target:
+      kind: Deployment
+  - path: service.yaml
+  # Work around an issue with RoleBinding in kustomize
+  - patch: |-
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: kube-plex
+      subjects:
+      - kind: ServiceAccount
+        name: my-kube-plex
+        namespace: plex

--- a/examples/kustomize/myplex/service.yaml
+++ b/examples/kustomize/myplex/service.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-plex
+spec:
+  # kustomize keeps wanting to overwrite this, so I'm hardcoding it
+  loadBalancerIP: 10.5.11.211


### PR DESCRIPTION
While the helm based template is useful to get started, it has
limitations. The Kustomize based can be used to take a base
configuration from this repository and deployment specific changes can
be overlaid on the base configuration.