### PR TITLE
Add Chart releaser Github workflow

### DIFF
--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -1,0 +1,33 @@
+name: Release Chart
+
+on:
+  # Triggers the workflow on push events only for the main branch
+  push:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.7.1
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.2.1
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This adds a workflow to publish Helm Charts to the `gh-pages` branch (which will need to be created prior to merging this, for this workflow to work), allowing users to install the Helm chart through a Helm repo hosted on GitHub, like the following:

```bash
helm repo add kube-plex https://ressu.github.io/kube-plex
helm search kube-plex
```

There is also a landing page served up from the README file, so the `gh-pages` version of the primary README file can be updated with these instructions as well.

If this is not something you want to add to the repo (and have another long-lived branch for the chart artifacts), that's fine too 😃 