### PR TITLE
kube-plex: update use of deprecated annotation

### DIFF
--- a/charts/kube-plex/README.md
+++ b/charts/kube-plex/README.md
@@ -37,7 +37,7 @@ The following tables lists the configurable parameters of the Plex chart and the
 | `ingress.hosts`                | Ingress accepted hostnames | `chart-example.local` |
 | `ingress.tls`                  | Ingress TLS configuration | `[]` |
 | `rbac.create`                  | Create RBAC roles? | `true` |
-| `nodeSelector`             | Node labels for pod assignment | `beta.kubernetes.io/arch: amd64` |
+| `nodeSelector`             | Node labels for pod assignment | `kubernetes.io/arch: amd64` |
 | `persistence.transcode.enabled`      | Use persistent volume for transcoding | `false` |
 | `persistence.transcode.size`         | Size of persistent volume claim | `20Gi` |
 | `persistence.transcode.claimName`| Use an existing PVC to persist data | `nil` |

--- a/charts/kube-plex/values.yaml
+++ b/charts/kube-plex/values.yaml
@@ -131,7 +131,7 @@ rbac:
   ## serviceAccountName: ""
 
 nodeSelector:
-  beta.kubernetes.io/arch: amd64
+  kubernetes.io/arch: amd64
 
 persistence:
   transcode:

--- a/cmd/kube-plex/kubernetes.go
+++ b/cmd/kube-plex/kubernetes.go
@@ -38,7 +38,7 @@ func generateJob(cwd string, m PmsMetadata, env []string, args []string) (*batch
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					NodeSelector: map[string]string{
-						"beta.kubernetes.io/arch": "amd64",
+						"kubernetes.io/arch": "amd64",
 					},
 					RestartPolicy: corev1.RestartPolicyNever,
 					Containers: []corev1.Container{

--- a/cmd/kube-plex/kubernetes_test.go
+++ b/cmd/kube-plex/kubernetes_test.go
@@ -233,7 +233,7 @@ func Test_generateJob(t *testing.T) {
 						Command:      []string{"cp", "/transcode-launcher", "/shared/transcode-launcher"},
 						VolumeMounts: []corev1.VolumeMount{{Name: "shared", MountPath: "/shared", ReadOnly: false}},
 					}},
-					NodeSelector:  map[string]string{"beta.kubernetes.io/arch": "amd64"},
+					NodeSelector:  map[string]string{"kubernetes.io/arch": "amd64"},
 					RestartPolicy: corev1.RestartPolicyNever,
 					Containers: []corev1.Container{{
 						Name:    "plex",

--- a/examples/kustomize/base/deployment.yaml
+++ b/examples/kustomize/base/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       # TODO: Make dynamic
       hostname: "kube-plex"
       nodeSelector:
-        beta.kubernetes.io/arch: amd64
+        kubernetes.io/arch: amd64
       initContainers:
         - name: kube-plex-init
           image: "ghcr.io/ressu/kube-plex:latest"


### PR DESCRIPTION
Saw these warnings:

```
W0621 21:05:43.621082   90780 warnings.go:70] spec.template.spec.nodeSelector[beta.kubernetes.io/arch]: deprecated since v1.14; use "kubernetes.io/arch" instead
```

Figured [1.14](https://kubernetes.io/blog/2019/03/25/kubernetes-1-14-release-announcement/) has been out for over two years, so probably fair to update this annotation.