### PR TITLE
initial wag at adding nodeselector reflection

### DIFF
--- a/cmd/kube-plex/kubernetes.go
+++ b/cmd/kube-plex/kubernetes.go
@@ -37,9 +37,7 @@ func generateJob(cwd string, m PmsMetadata, env []string, args []string) (*batch
 			TTLSecondsAfterFinished: &ttl,
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					NodeSelector: map[string]string{
-						"kubernetes.io/arch": "amd64",
-					},
+					NodeSelector: m.NodeSelector,
 					RestartPolicy: corev1.RestartPolicyNever,
 					Containers: []corev1.Container{
 						{

--- a/cmd/kube-plex/metadata.go
+++ b/cmd/kube-plex/metadata.go
@@ -142,7 +142,7 @@ func getNodeSelector(nodeSelector, defname string, pod *corev1.Pod) (map[string]
 	if n != nil {
                 return n
 	} else {
-		return  map[string]string{"kubernetes.io/arch": "amd64"}
+		return  map[string]string{}
         }
 }
 


### PR DESCRIPTION
Addresses #45 

- modifies the pmsMetadata struct to add a NodeSelector property
- modifies kubernetes.go to update the NodeSelector to be m.NodeSelector

Not sure if this is the same use case everyone has, but this is something that I have needed for my cluster where I have a mix of different node resources, so I've had to add node labels to advertise compatibility for scheduling. This update passes through whatever nodeselectors are assigned to the plex pod into all spawned transcode jobs and pods. If for some reason it fails to get a result it should default to the current nodeSelector that's in use. I've tested this locally and it seems to work as desired, though my golang experience is next to none, so take that with a grain of salt.