### PR TITLE
Remove duplicate port

### DIFF
--- a/charts/kube-plex/templates/deployment.yaml
+++ b/charts/kube-plex/templates/deployment.yaml
@@ -102,8 +102,6 @@ spec:
         ports:
           - name: pms
             containerPort: {{ .Values.service.port }}
-          - name: http
-            containerPort: {{ .Values.service.port }}
           - name: https
             containerPort: 32443
         env:


### PR DESCRIPTION
Should fix this error I get during deployment:

```shell
resource plex/plex-kube-plex was not successfully created by the Kubernetes API server : failed to create typed patch object (plex/plex-kube-plex; apps/v1, Kind=Deployment): .spec.template.spec.containers[name="plex"].ports: duplicate entries for key [containerPort=32400,protocol="TCP"
```
