### PR TITLE
Fix ADVERTISE_IP to work with structured ingress paths

### DIFF
--- a/charts/kube-plex/templates/_helpers.tpl
+++ b/charts/kube-plex/templates/_helpers.tpl
@@ -14,3 +14,20 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create a list of values for ADVERTISE_IP
+*/}}
+{{- define "advertiseIp" -}}
+{{- $hosts := list -}}
+{{- range .Values.ingress.hosts -}}
+{{- if kindIs "string" . }}
+    {{- $hosts = printf "https://%s" . | append $hosts -}}
+    {{- $hosts = printf "https://%s:443" . | append $hosts -}}
+{{- else }}
+    {{- $hosts = printf "https://%s" .host | append $hosts -}}
+    {{- $hosts = printf "https://%s:443" .host | append $hosts -}}
+{{- end }}
+{{- end -}}
+{{ join "," $hosts }}
+{{- end -}}

--- a/charts/kube-plex/templates/deployment.yaml
+++ b/charts/kube-plex/templates/deployment.yaml
@@ -137,18 +137,10 @@ spec:
 {{- with .Values.extraEnv }}
     {{- get (fromYaml (include "env_vars" $)) "env" | toYaml | nindent 8  -}}
 {{- end }}
+{{- if not (empty (include "advertiseIp" .)) }}
         # Fill ADVERTISE_IP section in plex automatically
-{{- if (or (eq .Values.service.type "ClusterIP") (empty .Values.service.type)) }}
         - name: ADVERTISE_IP
           value: {{ include "advertiseIp" . }}
-{{- else if eq .Values.service.type "LoadBalancer" }}
-  {{- if (or .Values.service.loadBalancerIP .Values.ingress.hosts (index .Values.service.annotations "dns.pfsense.org/hostname")) }}
-        - name: ADVERTISE_IP
-          value: |
-            {{ if .Values.service.loadBalancerIP }}https://{{ .Values.service.loadBalancerIP }}:32400{{ end }}
-            {{ if index .Values.service.annotations "dns.pfsense.org/hostname" }},https://{{ join ",https://" (splitList "," (index .Values.service.annotations "dns.pfsense.org/hostname")) }}:32400{{ end }}
-            {{ if .Values.ingress.hosts }},{{ include "advertiseIp" . }}{{ end }}
-  {{- end }}
 {{- end }}
         volumeMounts:
         - name: data

--- a/charts/kube-plex/templates/deployment.yaml
+++ b/charts/kube-plex/templates/deployment.yaml
@@ -140,17 +140,14 @@ spec:
         # Fill ADVERTISE_IP section in plex automatically
 {{- if (or (eq .Values.service.type "ClusterIP") (empty .Values.service.type)) }}
         - name: ADVERTISE_IP
-          value: |
-            {{ if .Values.ingress.hosts }}https://{{ join ",https://" .Values.ingress.hosts }}{{ end }}
-            {{ if .Values.ingress.hosts }},https://{{ join ",https://" .Values.ingress.hosts }}:443{{ end }}
+          value: {{ include "advertiseIp" . }}
 {{- else if eq .Values.service.type "LoadBalancer" }}
   {{- if (or .Values.service.loadBalancerIP .Values.ingress.hosts (index .Values.service.annotations "dns.pfsense.org/hostname")) }}
         - name: ADVERTISE_IP
           value: |
             {{ if .Values.service.loadBalancerIP }}https://{{ .Values.service.loadBalancerIP }}:32400{{ end }}
             {{ if index .Values.service.annotations "dns.pfsense.org/hostname" }},https://{{ join ",https://" (splitList "," (index .Values.service.annotations "dns.pfsense.org/hostname")) }}:32400{{ end }}
-            {{ if .Values.ingress.hosts }},https://{{ join ",https://" .Values.ingress.hosts }}{{ end }}
-            {{ if .Values.ingress.hosts }},https://{{ join ",https://" .Values.ingress.hosts }}:443{{ end }}
+            {{ if .Values.ingress.hosts }},{{ include "advertiseIp" . }}{{ end }}
   {{- end }}
 {{- end }}
         volumeMounts:


### PR DESCRIPTION
Moves ADVERTISE_IP logic to a helper function
Fixes the regression from #52

I believe this should have roughly equivalent output to the original.

Here are a few of the commands I tested with
`helm template . --set 'ingress.enabled=true' --set 'ingress.hosts[0]=test.example.com' --set 'ingress.hosts[1]=test2.example.com'`
`helm template . --set 'ingress.enabled=true' --set 'ingress.hosts[0].host=test.example.com' --set 'ingress.hosts[1].host=test2.example.com'`

I noticed that on `main` the first url doesn't seem to get a `:443` variant and is duplicated instead. Was this intentional?

Main renders:
```yaml
- name: ADVERTISE_IP
  value: |
    https://test.example.com,https://test2.example.com
    ,https://test.example.com,https://test2.example.com:443
```

This branch renders (whitespace added for readability):
```yaml
- name: ADVERTISE_IP
  value: |
    https://test.example.com,https://test.example.com:443
    ,https://test2.example.com,https://test2.example.com:443
```